### PR TITLE
Apotheosis enchantment compatibility

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -109,11 +109,6 @@ repositories {
     }
 
     maven {
-        name 'JEI maven'
-        url = "https://dvs1.progwml6.com/files/maven"
-    }
-
-    maven {
         url "https://maven.blamejared.com"
     }
     maven {

--- a/src/main/java/elucent/eidolon/Config.java
+++ b/src/main/java/elucent/eidolon/Config.java
@@ -7,7 +7,8 @@ import org.apache.commons.lang3.tuple.Pair;
 public class Config {
 	// generic
 	public static ConfigValue<Integer> CRUCIBLE_STEP_DURATION, MAX_ETHEREAL_HEALTH;
-    public static ConfigValue<Integer> MAXIMUM_SOUL_ENCHANTING_USES;
+    public static ConfigValue<Integer> SOUL_ENCHANTER_MAXIMUM_USES;
+    public static ConfigValue<Integer> SOUL_ENCHANTER_MAXIMUM_ENCHANTMENTS;
 
     public Config(ForgeConfigSpec.Builder builder) {
         builder.comment("Generic settings").push("generic");
@@ -15,8 +16,10 @@ public class Config {
         		.defineInRange("crucibleStepDuration", 100, 20, 1200);
         MAX_ETHEREAL_HEALTH = builder.comment("Maximum amount of ethereal health (soul half-hearts) an entity can have at once.")
         		.defineInRange("maxEtherealHealth", 80, 0, 1000);
-        MAXIMUM_SOUL_ENCHANTING_USES = builder.comment("How often the Soul Enchanter can apply enchantments on an item (a value below 0 means unlimited)")
-                .define("maximumSoulEnchantingUses", -1);
+        SOUL_ENCHANTER_MAXIMUM_USES = builder.comment("How often the Soul Enchanter can apply enchantments on an item (a value below 0 means unlimited)")
+                .define("soulEnchanterMaximumUses", -1);
+        SOUL_ENCHANTER_MAXIMUM_ENCHANTMENTS = builder.comment("How many enchantments the item is allowed to have to be applicable for soul enchanting (a value below 0 means unlimited)")
+                        .define("soulEnchanterMaximumEnchantments", -1);
         builder.pop();
 
     }

--- a/src/main/java/elucent/eidolon/Config.java
+++ b/src/main/java/elucent/eidolon/Config.java
@@ -7,6 +7,7 @@ import org.apache.commons.lang3.tuple.Pair;
 public class Config {
 	// generic
 	public static ConfigValue<Integer> CRUCIBLE_STEP_DURATION, MAX_ETHEREAL_HEALTH;
+    public static ConfigValue<Integer> MAXIMUM_SOUL_ENCHANTING_USES;
 
     public Config(ForgeConfigSpec.Builder builder) {
         builder.comment("Generic settings").push("generic");
@@ -14,6 +15,8 @@ public class Config {
         		.defineInRange("crucibleStepDuration", 100, 20, 1200);
         MAX_ETHEREAL_HEALTH = builder.comment("Maximum amount of ethereal health (soul half-hearts) an entity can have at once.")
         		.defineInRange("maxEtherealHealth", 80, 0, 1000);
+        MAXIMUM_SOUL_ENCHANTING_USES = builder.comment("How often the Soul Enchanter can apply enchantments on an item (a value below 0 means unlimited)")
+                .define("maximumSoulEnchantingUses", -1);
         builder.pop();
 
     }

--- a/src/main/java/elucent/eidolon/Eidolon.java
+++ b/src/main/java/elucent/eidolon/Eidolon.java
@@ -43,6 +43,8 @@ import net.minecraftforge.fml.event.lifecycle.FMLClientSetupEvent;
 import net.minecraftforge.fml.event.lifecycle.FMLCommonSetupEvent;
 import net.minecraftforge.fml.event.lifecycle.InterModEnqueueEvent;
 import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.NotNull;
 import top.theillusivec4.curios.api.SlotTypeMessage;
 import top.theillusivec4.curios.api.SlotTypePreset;
@@ -54,6 +56,7 @@ public class Eidolon {
     public static final ISidedProxy proxy = DistExecutor.unsafeRunForDist(() -> ClientProxy::new, () -> ServerProxy::new);
 
     public static final String MODID = "eidolon";
+    public static final Logger LOG = LogManager.getLogger("Eidolon Repraised");
 
     public static ResourceLocation prefix(String path) {
         return new ResourceLocation("eidolon", path);

--- a/src/main/java/elucent/eidolon/compat/Apotheosis.java
+++ b/src/main/java/elucent/eidolon/compat/Apotheosis.java
@@ -1,0 +1,64 @@
+package elucent.eidolon.compat;
+
+import elucent.eidolon.Eidolon;
+import net.minecraft.world.item.enchantment.Enchantment;
+import net.minecraftforge.fml.ModList;
+import net.minecraftforge.fml.util.ObfuscationReflectionHelper;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
+public class Apotheosis {
+    public static final boolean IS_LOADED = ModList.get().isLoaded("apotheosis");
+
+    private static Method getMaxLevel;
+    private static Method isTreasureOnly;
+
+    public static boolean isTreasureOnly(final Enchantment enchantment) {
+        initialize();
+
+        if (IS_LOADED && isInitialized()) {
+            try {
+                return (Boolean) isTreasureOnly.invoke(null, enchantment);
+            } catch (IllegalAccessException | InvocationTargetException exception) {
+                Eidolon.LOG.error("An error occurred while calling Apotheosis isTreasureOnly method", exception);
+            }
+        }
+
+        return enchantment.isTreasureOnly();
+    }
+
+    public static int getMaxLevel(final Enchantment enchantment) {
+        initialize();
+
+        if (IS_LOADED && isInitialized()) {
+            try {
+                return (Integer) getMaxLevel.invoke(null, enchantment);
+            } catch (IllegalAccessException | InvocationTargetException exception) {
+                Eidolon.LOG.error("An error occurred while calling Apotheosis isTreasureOnly method", exception);
+            }
+        }
+
+        return enchantment.getMaxLevel();
+    }
+
+    public static void initialize() {
+        if (!IS_LOADED || isInitialized()) {
+            return;
+        }
+
+        try {
+            Class<?> enchHooks = Class.forName("shadows.apotheosis.ench.asm.EnchHooks");
+            getMaxLevel = ObfuscationReflectionHelper.findMethod(enchHooks, "getMaxLevel", Enchantment.class);
+            isTreasureOnly = ObfuscationReflectionHelper.findMethod(enchHooks, "isTreasureOnly", Enchantment.class);
+        } catch (ClassNotFoundException exception) {
+            Eidolon.LOG.error("Apotheosis compatibility could not be loaded", exception);
+            getMaxLevel = null;
+            isTreasureOnly = null;
+        }
+    }
+
+    public static boolean isInitialized() {
+        return getMaxLevel != null && isTreasureOnly != null;
+    }
+}

--- a/src/main/java/elucent/eidolon/compat/Apotheosis.java
+++ b/src/main/java/elucent/eidolon/compat/Apotheosis.java
@@ -35,7 +35,7 @@ public class Apotheosis {
             try {
                 return (Integer) getMaxLevel.invoke(null, enchantment);
             } catch (IllegalAccessException | InvocationTargetException exception) {
-                Eidolon.LOG.error("An error occurred while calling Apotheosis isTreasureOnly method", exception);
+                Eidolon.LOG.error("An error occurred while calling Apotheosis getMaxLevel method", exception);
             }
         }
 

--- a/src/main/java/elucent/eidolon/gui/SoulEnchanterContainer.java
+++ b/src/main/java/elucent/eidolon/gui/SoulEnchanterContainer.java
@@ -235,9 +235,6 @@ public class SoulEnchanterContainer extends AbstractContainerMenu {
 
                     if (!playerIn.getAbilities().instabuild) {
                         incrementSoulEnchant(itemstack2);
-                    }
-
-                    if (!playerIn.getAbilities().instabuild) {
                         soulShards.shrink(1);
                         if (soulShards.isEmpty()) {
                             this.tableInventory.setItem(1, ItemStack.EMPTY);

--- a/src/main/java/elucent/eidolon/gui/SoulEnchanterContainer.java
+++ b/src/main/java/elucent/eidolon/gui/SoulEnchanterContainer.java
@@ -148,11 +148,19 @@ public class SoulEnchanterContainer extends AbstractContainerMenu {
     }
 
     private boolean isValidItem(final ItemStack itemStack) {
-        return !itemStack.isEmpty() && canSoulEnchant(itemStack) && (itemStack.isEnchantable() || itemStack.isEnchanted() || itemStack.getItem() == Items.ENCHANTED_BOOK);
+        return !itemStack.isEmpty() && canSoulEnchant(itemStack) && hasValidEnchantmentAmount(itemStack) && (itemStack.isEnchantable() || itemStack.isEnchanted() || itemStack.getItem() == Items.ENCHANTED_BOOK);
+    }
+
+    private boolean hasValidEnchantmentAmount(final ItemStack itemStack) {
+        if (Config.SOUL_ENCHANTER_MAXIMUM_ENCHANTMENTS.get() < 0) {
+            return true;
+        }
+
+        return itemStack.getAllEnchantments().size() <= Config.SOUL_ENCHANTER_MAXIMUM_ENCHANTMENTS.get();
     }
 
     private void incrementSoulEnchant(final ItemStack enchantedItem) {
-        if (Config.MAXIMUM_SOUL_ENCHANTING_USES.get() < 0) {
+        if (Config.SOUL_ENCHANTER_MAXIMUM_USES.get() < 0) {
             return;
         }
 
@@ -161,7 +169,7 @@ public class SoulEnchanterContainer extends AbstractContainerMenu {
     }
 
     private boolean canSoulEnchant(final ItemStack itemstack) {
-        if (Config.MAXIMUM_SOUL_ENCHANTING_USES.get() < 0) {
+        if (Config.SOUL_ENCHANTER_MAXIMUM_USES.get() < 0) {
             return true;
         }
 
@@ -169,7 +177,7 @@ public class SoulEnchanterContainer extends AbstractContainerMenu {
 
         if (tag != null) {
             int soulEnchantUses = tag.getInt(SOUL_ENCHANT_USES_TAG);
-            return soulEnchantUses < Config.MAXIMUM_SOUL_ENCHANTING_USES.get();
+            return soulEnchantUses < Config.SOUL_ENCHANTER_MAXIMUM_USES.get();
         }
 
         return true;

--- a/src/main/java/elucent/eidolon/gui/SoulEnchanterContainer.java
+++ b/src/main/java/elucent/eidolon/gui/SoulEnchanterContainer.java
@@ -1,6 +1,8 @@
 package elucent.eidolon.gui;
 
 import com.google.common.collect.Lists;
+import elucent.eidolon.Config;
+import elucent.eidolon.compat.Apotheosis;
 import elucent.eidolon.registries.Registry;
 import net.minecraft.advancements.CriteriaTriggers;
 import net.minecraft.core.BlockPos;
@@ -35,6 +37,8 @@ import org.jetbrains.annotations.NotNull;
 import java.util.*;
 
 public class SoulEnchanterContainer extends AbstractContainerMenu {
+    private static final String SOUL_ENCHANT_USES_TAG = "soul_enchant_uses";
+
     private final Container tableInventory = new SimpleContainer(2) {
         public void setChanged() {
             super.setChanged();
@@ -95,7 +99,7 @@ public class SoulEnchanterContainer extends AbstractContainerMenu {
     public void slotsChanged(@NotNull Container inventoryIn) {
         if (inventoryIn == this.tableInventory) {
             ItemStack itemstack = inventoryIn.getItem(0);
-            if (!itemstack.isEmpty() && (itemstack.isEnchantable() || itemstack.isEnchanted() || itemstack.getItem() == Items.ENCHANTED_BOOK)) {
+            if (isValidItem(itemstack)) {
                 this.worldPosCallable.execute((world, pos) -> {
                     int power = 0;
 
@@ -143,23 +147,58 @@ public class SoulEnchanterContainer extends AbstractContainerMenu {
 
     }
 
+    private boolean isValidItem(final ItemStack itemStack) {
+        return !itemStack.isEmpty() && canSoulEnchant(itemStack) && (itemStack.isEnchantable() || itemStack.isEnchanted() || itemStack.getItem() == Items.ENCHANTED_BOOK);
+    }
+
+    private void incrementSoulEnchant(final ItemStack enchantedItem) {
+        if (Config.MAXIMUM_SOUL_ENCHANTING_USES.get() < 0) {
+            return;
+        }
+
+        CompoundTag tag = enchantedItem.getOrCreateTag();
+        tag.putInt(SOUL_ENCHANT_USES_TAG, tag.getInt(SOUL_ENCHANT_USES_TAG) + 1);
+    }
+
+    private boolean canSoulEnchant(final ItemStack itemstack) {
+        if (Config.MAXIMUM_SOUL_ENCHANTING_USES.get() < 0) {
+            return true;
+        }
+
+        CompoundTag tag = itemstack.getTag();
+
+        if (tag != null) {
+            int soulEnchantUses = tag.getInt(SOUL_ENCHANT_USES_TAG);
+            return soulEnchantUses < Config.MAXIMUM_SOUL_ENCHANTING_USES.get();
+        }
+
+        return true;
+    }
+
     /**
      * Handles the given Button-click on the server, currently only used by enchanting. Name is for legacy.
      */
     public boolean clickMenuButton(@NotNull Player playerIn, int id) {
         ItemStack itemstack = this.tableInventory.getItem(0);
-        ItemStack itemstack1 = this.tableInventory.getItem(1);
-        int i = id + 1;
-        if ((itemstack1.isEmpty() || itemstack1.getCount() < 1) && !playerIn.getAbilities().instabuild) {
+
+        if (!isValidItem(itemstack)) {
             return false;
-        } else if (itemstack.isEmpty() || playerIn.experienceLevel < this.worldClue[id] && !playerIn.getAbilities().instabuild) {
+        }
+
+        ItemStack soulShards = this.tableInventory.getItem(1);
+        int i = id + 1;
+        // Texture only goes up to 5 - maybe need to dynamically render the level?
+        int experienceLevelCost = Math.min(5, this.worldClue[id]);
+        if ((soulShards.isEmpty() || soulShards.getCount() < 1) && !playerIn.getAbilities().instabuild) {
+            return false;
+        } else if (itemstack.isEmpty() || playerIn.experienceLevel < experienceLevelCost && !playerIn.getAbilities().instabuild) {
             return false;
         } else {
             this.worldPosCallable.execute((p_217003_6_, p_217003_7_) -> {
                 ItemStack itemstack2 = itemstack;
                 List<EnchantmentInstance> list = this.getEnchantmentList(itemstack, id);
                 if (!list.isEmpty()) {
-                    playerIn.onEnchantmentPerformed(itemstack, worldClue[id]);
+                    playerIn.onEnchantmentPerformed(itemstack, experienceLevelCost);
                     boolean flag = itemstack.getItem() == Items.BOOK;
                     if (flag) {
                         itemstack2 = new ItemStack(Items.ENCHANTED_BOOK);
@@ -187,8 +226,12 @@ public class SoulEnchanterContainer extends AbstractContainerMenu {
                     }
 
                     if (!playerIn.getAbilities().instabuild) {
-                        itemstack1.shrink(1);
-                        if (itemstack1.isEmpty()) {
+                        incrementSoulEnchant(itemstack2);
+                    }
+
+                    if (!playerIn.getAbilities().instabuild) {
+                        soulShards.shrink(1);
+                        if (soulShards.isEmpty()) {
                             this.tableInventory.setItem(1, ItemStack.EMPTY);
                         }
                     }
@@ -239,10 +282,16 @@ public class SoulEnchanterContainer extends AbstractContainerMenu {
         valid.removeIf((ench) -> {
             boolean canApply = ench.canEnchant(finalTest) ||
                 finalTest.getItem() == Items.BOOK && ench.isAllowedOnBooks();
-            return !canApply
-                || ench.isTreasureOnly()
-                || existing.containsKey(ench) && existing.get(ench) >= ench.getMaxLevel()
-                || ench.isCurse();
+
+            if (!canApply || ench.isCurse()) {
+                return true;
+            }
+
+            if (Apotheosis.IS_LOADED) {
+                return Apotheosis.isTreasureOnly(ench) || existing.containsKey(ench) && existing.get(ench) >= Apotheosis.getMaxLevel(ench);
+            }
+
+            return ench.isTreasureOnly() || existing.containsKey(ench) && existing.get(ench) >= ench.getMaxLevel();
         });
 
         for (Map.Entry<Enchantment, Integer> e : existing.entrySet()) {

--- a/src/main/java/elucent/eidolon/gui/SoulEnchanterScreen.java
+++ b/src/main/java/elucent/eidolon/gui/SoulEnchanterScreen.java
@@ -137,17 +137,17 @@ public class SoulEnchanterScreen extends AbstractContainerScreen<SoulEnchanterCo
             int k1 = j1 + 20;
             this.setBlitOffset(0);
             RenderSystem.setShaderTexture(0, ENCHANTMENT_TABLE_GUI_TEXTURE);
-            int l1 = menu.worldClue[i1];
+            int experienceLevelCost = Math.min(5, menu.worldClue[i1]);
             RenderSystem.setShaderColor(1.0F, 1.0F, 1.0F, 1.0F);
             int i2 = 86;
             FormattedText itextproperties = EnchantmentNames.getInstance().getRandomName(this.font, i2);
             int j2 = 6839882;
-            if (l1 < 1) {
+            if (experienceLevelCost < 1) {
                 this.blit(matrixStack, j1, j + 14 + 19 * i1, 0, 185, 108, 19);
             } else {
-                if (((l == 0 || this.minecraft.player.experienceLevel < l1) && !this.minecraft.player.getAbilities().instabuild) || this.menu.enchantClue[i1] == -1) { // Forge: render buttons as disabled when enchantable but enchantability not met on lower levels
+                if (((l == 0 || this.minecraft.player.experienceLevel < experienceLevelCost) && !this.minecraft.player.getAbilities().instabuild) || this.menu.enchantClue[i1] == -1) { // Forge: render buttons as disabled when enchantable but enchantability not met on lower levels
                     this.blit(matrixStack, j1, j + 14 + 19 * i1, 0, 185, 108, 19);
-                    this.blit(matrixStack, j1 + 1, j + 15 + 19 * i1, 16 * (menu.worldClue[i1] - 1), 239, 16, 16);
+                    this.blit(matrixStack, j1 + 1, j + 15 + 19 * i1, 16 * (experienceLevelCost - 1), 239, 16, 16);
                     this.font.drawWordWrap(itextproperties, k1, j + 16 + 19 * i1, i2, (j2 & 16711422) >> 1);
                     j2 = 4226832;
                 } else {
@@ -160,7 +160,7 @@ public class SoulEnchanterScreen extends AbstractContainerScreen<SoulEnchanterCo
                         this.blit(matrixStack, j1, j + 14 + 19 * i1, 0, 166, 108, 19);
                     }
 
-                    this.blit(matrixStack, j1 + 1, j + 15 + 19 * i1, 16 * (menu.worldClue[i1] - 1), 223, 16, 16);
+                    this.blit(matrixStack, j1 + 1, j + 15 + 19 * i1, 16 * (experienceLevelCost - 1), 223, 16, 16);
                     this.font.drawWordWrap(itextproperties, k1, j + 16 + 19 * i1, i2, j2);
                     j2 = 8453920;
                 }

--- a/src/main/java/elucent/eidolon/gui/SoulEnchanterScreen.java
+++ b/src/main/java/elucent/eidolon/gui/SoulEnchanterScreen.java
@@ -174,31 +174,31 @@ public class SoulEnchanterScreen extends AbstractContainerScreen<SoulEnchanterCo
         super.render(matrixStack, mouseX, mouseY, partialTicks);
         this.renderTooltip(matrixStack, mouseX, mouseY);
         boolean flag = this.minecraft.player.getAbilities().instabuild;
-        int i = this.menu.getSoulShardAmount();
+        int soulShardAmount = this.menu.getSoulShardAmount();
 
         for (int j = 0; j < 3; ++j) {
             Enchantment enchantment = Enchantment.byId((this.menu).enchantClue[j]);
-            int l = (this.menu).worldClue[j];
-            int i1 = j + 1;
-            if (this.isHovering(60, 14 + 19 * j, 108, 17, mouseX, mouseY) && l > 0) {
+            int enchantmentLevel = (this.menu).worldClue[j];
+            int experienceLevelCost = Math.min(5, enchantmentLevel);
+            if (this.isHovering(60, 14 + 19 * j, 108, 17, mouseX, mouseY) && enchantmentLevel > 0) {
                 List<Component> list = Lists.newArrayList();
-                list.add(enchantment == null ? Component.literal("") : enchantment.getFullname(l));
+                list.add(enchantment == null ? Component.literal("") : enchantment.getFullname(enchantmentLevel));
                 if (enchantment == null) {
                     list.add(Component.literal(""));
                     list.add(Component.translatable("forge.container.enchant.limitedEnchantability").withStyle(ChatFormatting.RED));
                 } else if (!flag) {
                     list.add(Component.empty());
-                    if (this.minecraft.player.experienceLevel < l) {
-                        list.add((Component.translatable("container.enchant.level.requirement", l)).withStyle(ChatFormatting.RED));
+                    if (this.minecraft.player.experienceLevel < experienceLevelCost) {
+                        list.add((Component.translatable("container.enchant.level.requirement", experienceLevelCost)).withStyle(ChatFormatting.RED));
                     } else {
                         MutableComponent iformattabletextcomponent = Component.translatable("container.eidolon.enchant.shard.one", 1);
 
-                        list.add(iformattabletextcomponent.withStyle(minecraft.player.experienceLevel >= l ? ChatFormatting.GRAY : ChatFormatting.RED));
+                        list.add(iformattabletextcomponent.withStyle(soulShardAmount > 0 ? ChatFormatting.GRAY : ChatFormatting.RED));
                         MutableComponent iformattabletextcomponent1;
-                        if (l == 1) {
+                        if (experienceLevelCost == 1) {
                             iformattabletextcomponent1 = Component.translatable("container.enchant.level.one");
                         } else {
-                            iformattabletextcomponent1 = Component.translatable("container.enchant.level.many", menu.worldClue[i1 - 1]);
+                            iformattabletextcomponent1 = Component.translatable("container.enchant.level.many", experienceLevelCost);
                         }
 
                         list.add(iformattabletextcomponent1.withStyle(ChatFormatting.GRAY));


### PR DESCRIPTION
Support for max. level and treasure enchant check
Enchantment cost is capped at 5 because that's as far as the texture goes

![q5XLbA8](https://github.com/Alexthw46/Eidolon-Repraised/assets/22003703/41ac2fa3-efe0-4fb6-a6c9-4880a2dac0e5)

Added two configs
- Maximum amount of enchantments an item can have for it to be soul enchanted (unlimited by default)
- Maximum amount of times an item can be soul enchanted (tracked by NBT per item) (unlimited by default)