### PR TITLE
apotheosis update

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -144,9 +144,9 @@ dependencies {
     //implementation fg.deobf("curse.maven:embeddium-908741:4800420")
     //implementation fg.deobf("curse.maven:modernfix-790626:4792389")
 
-    implementation fg.deobf("curse.maven:placebo-283644:4723708")
-    implementation fg.deobf("curse.maven:apothic-attributes-898963:4731488")
-    implementation fg.deobf("curse.maven:apotheosis-313970:4724390")
+    implementation fg.deobf("curse.maven:placebo-283644:4872439")
+    implementation fg.deobf("curse.maven:apothic-attributes-898963:4872467")
+    implementation fg.deobf("curse.maven:apotheosis-313970:4874713")
 
     annotationProcessor 'org.spongepowered:mixin:0.8.5:processor'
 }

--- a/src/main/java/elucent/eidolon/compat/apotheosis/Apotheosis.java
+++ b/src/main/java/elucent/eidolon/compat/apotheosis/Apotheosis.java
@@ -41,8 +41,8 @@ public class Apotheosis {
     }
 
     public static void initialize() {
-        AffixRegistry.INSTANCE.registerSerializer(new ResourceLocation(Eidolon.MODID, "tracking"), TrackingAffix.SERIALIZER);
-        AffixRegistry.INSTANCE.registerSerializer(new ResourceLocation(Eidolon.MODID, "hailing"), HailingAffix.SERIALIZER);
+        AffixRegistry.INSTANCE.registerCodec(new ResourceLocation(Eidolon.MODID, "tracking"), TrackingAffix.CODEC);
+        AffixRegistry.INSTANCE.registerCodec(new ResourceLocation(Eidolon.MODID, "hailing"), HailingAffix.CODEC);
     }
 
     public static Pair<Integer, Integer> handleWandAffix(final ItemStack stack) {

--- a/src/main/java/elucent/eidolon/compat/apotheosis/HailingAffix.java
+++ b/src/main/java/elucent/eidolon/compat/apotheosis/HailingAffix.java
@@ -7,7 +7,6 @@ import dev.shadowsoffire.apotheosis.adventure.affix.AffixType;
 import dev.shadowsoffire.apotheosis.adventure.affix.socket.gem.bonus.GemBonus;
 import dev.shadowsoffire.apotheosis.adventure.loot.LootCategory;
 import dev.shadowsoffire.apotheosis.adventure.loot.LootRarity;
-import dev.shadowsoffire.placebo.json.PSerializer;
 import dev.shadowsoffire.placebo.util.StepFunction;
 import net.minecraft.network.chat.Component;
 import net.minecraft.world.item.ItemStack;
@@ -18,10 +17,8 @@ import java.util.function.Consumer;
 
 public class HailingAffix extends Affix implements Apotheosis.StepScalingAffix {
     public static final Codec<HailingAffix> CODEC = RecordCodecBuilder.create(inst -> inst.group(GemBonus.VALUES_CODEC.fieldOf("values").forGetter((a) -> a.values)).apply(inst, HailingAffix::new));
+
     protected final Map<LootRarity, StepFunction> values;
-
-
-    public static final PSerializer<HailingAffix> SERIALIZER = PSerializer.fromCodec("Hailing Affix", CODEC);
 
     public HailingAffix(Map<LootRarity, StepFunction> values) {
         super(AffixType.ABILITY);
@@ -39,12 +36,12 @@ public class HailingAffix extends Affix implements Apotheosis.StepScalingAffix {
     }
 
     @Override
-    public PSerializer<? extends Affix> getSerializer() {
-        return SERIALIZER;
+    public @NotNull Map<LootRarity, StepFunction> getValues() {
+        return values;
     }
 
     @Override
-    public @NotNull Map<LootRarity, StepFunction> getValues() {
-        return values;
+    public Codec<? extends Affix> getCodec() {
+        return CODEC;
     }
 }

--- a/src/main/java/elucent/eidolon/compat/apotheosis/TrackingAffix.java
+++ b/src/main/java/elucent/eidolon/compat/apotheosis/TrackingAffix.java
@@ -7,7 +7,6 @@ import dev.shadowsoffire.apotheosis.adventure.affix.AffixType;
 import dev.shadowsoffire.apotheosis.adventure.affix.socket.gem.bonus.GemBonus;
 import dev.shadowsoffire.apotheosis.adventure.loot.LootCategory;
 import dev.shadowsoffire.apotheosis.adventure.loot.LootRarity;
-import dev.shadowsoffire.placebo.json.PSerializer;
 import dev.shadowsoffire.placebo.util.StepFunction;
 import net.minecraft.network.chat.Component;
 import net.minecraft.world.item.ItemStack;
@@ -17,23 +16,14 @@ import java.util.Map;
 import java.util.function.Consumer;
 
 public class TrackingAffix extends Affix implements Apotheosis.StepScalingAffix {
-
     public static final Codec<TrackingAffix> CODEC = RecordCodecBuilder.create(inst -> inst.group(GemBonus.VALUES_CODEC.fieldOf("values").forGetter((a) -> a.values)).apply(inst, TrackingAffix::new));
 
-    public @NotNull Map<LootRarity, StepFunction> getValues() {
-        return values;
-    }
-
     protected final Map<LootRarity, StepFunction> values;
-
-
-    public static final PSerializer<TrackingAffix> SERIALIZER = PSerializer.fromCodec("Tracking Affix", CODEC);
 
     public TrackingAffix(Map<LootRarity, StepFunction> values) {
         super(AffixType.ABILITY);
         this.values = values;
     }
-
 
     @Override
     public boolean canApplyTo(final ItemStack stack, final LootCategory category, final LootRarity rarity) {
@@ -45,8 +35,12 @@ public class TrackingAffix extends Affix implements Apotheosis.StepScalingAffix 
         list.accept(Component.translatable("affix." + this.getId() + ".desc", fmt(affixToAmount(rarity, level))));
     }
 
+    public @NotNull Map<LootRarity, StepFunction> getValues() {
+        return values;
+    }
+
     @Override
-    public PSerializer<? extends Affix> getSerializer() {
-        return SERIALIZER;
+    public Codec<? extends Affix> getCodec() {
+        return CODEC;
     }
 }

--- a/src/main/resources/data/eidolon/affixes/wand/attribute/magic_power.json
+++ b/src/main/resources/data/eidolon/affixes/wand/attribute/magic_power.json
@@ -36,6 +36,7 @@
   },
   "types": [
     "wand",
-    "armor"
+    "helmet",
+    "chestplate"
   ]
 }


### PR DESCRIPTION
- support for latest version
- `armor` is not (no longer?) a valid loot category