### PR TITLE
Added ability to put the Ars Ecclesia in Chiseled Bookshelves

### DIFF
--- a/src/main/resources/data/minecraft/tags/items/bookshelf_books.json
+++ b/src/main/resources/data/minecraft/tags/items/bookshelf_books.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "eidolon:codex"
+  ]
+}


### PR DESCRIPTION
It only makes sense that a book should be able to be placed on a bookshelf.