### PR TITLE
[1.21.1] Fix some bugs

### DIFF
--- a/src/main/java/alexthw/eidolon_repraised/common/incense/DeathBaneIncense.java
+++ b/src/main/java/alexthw/eidolon_repraised/common/incense/DeathBaneIncense.java
@@ -20,7 +20,7 @@ public class DeathBaneIncense extends GenericPotionIncense {
 
     @Override
     public MobEffectInstance getEffect(Level level, BlockPos blockPos, LivingEntity livingEntity) {
-        return livingEntity.getType().is(EntityTypeTags.UNDEAD) ?
+        return !livingEntity.getType().is(EntityTypeTags.UNDEAD) ?
                 new MobEffectInstance(EidolonPotions.LIGHT_BLESSED, 20 * 60 * 10) :
                 new MobEffectInstance(MobEffects.CONFUSION, 20 * 60 * 2);
     }

--- a/src/main/java/alexthw/eidolon_repraised/common/incense/GloomIncense.java
+++ b/src/main/java/alexthw/eidolon_repraised/common/incense/GloomIncense.java
@@ -50,7 +50,7 @@ public class GloomIncense extends IncenseRitual {
             BlockPos pos = censer.getBlockPos();
             assert level != null;
             for (LivingEntity entity : level.getEntitiesOfClass(LivingEntity.class, new AABB(pos).inflate(range()))) {
-                if (entity.getType().is(EntityTypeTags.UNDEAD)) {
+                if (!entity.getType().is(EntityTypeTags.UNDEAD)) {
                     entity.addEffect(new MobEffectInstance(MobEffects.WITHER, 200, 1));
                 } else {
                     entity.heal(1);

--- a/src/main/java/alexthw/eidolon_repraised/common/incense/PurityIncense.java
+++ b/src/main/java/alexthw/eidolon_repraised/common/incense/PurityIncense.java
@@ -5,6 +5,7 @@ import alexthw.eidolon_repraised.client.particle.Particles;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.particles.ParticleTypes;
 import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.effect.MobEffectInstance;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.phys.AABB;
@@ -52,7 +53,11 @@ public class PurityIncense extends IncenseRitual {
             BlockPos pos = censer.getBlockPos();
             assert level != null;
             for (LivingEntity entity : level.getEntitiesOfClass(LivingEntity.class, new AABB(pos).inflate(range()))) {
-                entity.getActiveEffects().removeIf(effect -> !effect.getEffect().value().isBeneficial() && !effect.getCures().isEmpty());
+                entity.getActiveEffects().stream()
+                        .filter(effect -> !effect.getEffect().value().isBeneficial() && !effect.getCures().isEmpty())
+                        .map(MobEffectInstance::getEffect)
+                        .toList()
+                        .forEach(entity::removeEffect);
             }
         }
     }

--- a/src/main/java/alexthw/eidolon_repraised/common/tile/CrucibleTileEntity.java
+++ b/src/main/java/alexthw/eidolon_repraised/common/tile/CrucibleTileEntity.java
@@ -339,7 +339,8 @@ public class CrucibleTileEntity extends TileEntityBase implements Container {
         } else {
             CrucibleStep step = new CrucibleStep(stirs, contents);
             steps.add(step);
-            level.updateNeighbourForOutputSignal(worldPosition, getBlockState().getBlock());
+            // update observer
+            getBlockState().updateNeighbourShapes(level, worldPosition, 3);
             stirs = 0;
 
             // try to find a finished recipe with the current steps
@@ -387,7 +388,8 @@ public class CrucibleTileEntity extends TileEntityBase implements Container {
         List<ItemStack> consumed = consumeFromInventory();
         CrucibleStep finalStep = new CrucibleStep(stirs, consumed);
         steps.add(finalStep);
-        level.updateNeighbourForOutputSignal(worldPosition, getBlockState().getBlock());
+        // update observer
+        getBlockState().updateNeighbourShapes(level, worldPosition, 3);
 
         stirs = 0;
 

--- a/src/main/resources/data/eidolon_repraised/loot_table/blocks/mirecap.json
+++ b/src/main/resources/data/eidolon_repraised/loot_table/blocks/mirecap.json
@@ -1,0 +1,43 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "rolls": 1.0,
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "eidolon_repraised:mirecap"
+        }
+      ]
+    },
+    {
+      "rolls": 1.0,
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "conditions": [
+            {
+              "condition": "minecraft:random_chance",
+              "chance": 0.5
+            }
+          ],
+          "name": "eidolon_repraised:mirecap"
+        }
+      ],
+      "conditions": [
+        {
+          "condition": "minecraft:block_state_property",
+          "block": "eidolon_repraised:mirecap",
+          "properties": {
+            "age": "3"
+          }
+        }
+      ]
+    }
+  ],
+  "functions": [
+    {
+      "function": "minecraft:explosion_decay"
+    }
+  ]
+}

--- a/src/main/resources/data/eidolon_repraised/loot_table/blocks/polished_button.json
+++ b/src/main/resources/data/eidolon_repraised/loot_table/blocks/polished_button.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "eidolon_repraised:polished_button"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ],
+  "random_sequence": "eidolon_repraised:blocks/polished_button"
+}

--- a/src/main/resources/data/eidolon_repraised/loot_table/blocks/polished_hanging_sign.json
+++ b/src/main/resources/data/eidolon_repraised/loot_table/blocks/polished_hanging_sign.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "eidolon_repraised:polished_hanging_sign"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ],
+  "random_sequence": "eidolon_repraised:blocks/polished_hanging_sign"
+}

--- a/src/main/resources/data/eidolon_repraised/loot_table/blocks/polished_hanging_wall_sign.json
+++ b/src/main/resources/data/eidolon_repraised/loot_table/blocks/polished_hanging_wall_sign.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "eidolon_repraised:polished_hanging_sign"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ],
+  "random_sequence": "eidolon_repraised:blocks/polished_hanging_wall_sign"
+}

--- a/src/main/resources/data/eidolon_repraised/loot_table/blocks/polished_pressure_plate.json
+++ b/src/main/resources/data/eidolon_repraised/loot_table/blocks/polished_pressure_plate.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "eidolon_repraised:polished_pressure_plate"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ],
+  "random_sequence": "eidolon_repraised:blocks/polished_pressure_plate"
+}

--- a/src/main/resources/data/eidolon_repraised/loot_table/blocks/polished_standing_sign.json
+++ b/src/main/resources/data/eidolon_repraised/loot_table/blocks/polished_standing_sign.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "eidolon_repraised:polished_sign"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ],
+  "random_sequence": "eidolon_repraised:blocks/polished_standing_sign"
+}

--- a/src/main/resources/data/eidolon_repraised/loot_table/blocks/polished_wall_sign.json
+++ b/src/main/resources/data/eidolon_repraised/loot_table/blocks/polished_wall_sign.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "eidolon_repraised:polished_sign"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ],
+  "random_sequence": "eidolon_repraised:blocks/polished_wall_sign"
+}

--- a/src/main/resources/data/eidolon_repraised/loot_table/blocks/scriptorium.json
+++ b/src/main/resources/data/eidolon_repraised/loot_table/blocks/scriptorium.json
@@ -1,0 +1,19 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "rolls": 1,
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "eidolon_repraised:scriptorium"
+        }
+      ],
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ]
+    }
+  ]
+}

--- a/src/main/resources/data/minecraft/tags/block/mineable/axe.json
+++ b/src/main/resources/data/minecraft/tags/block/mineable/axe.json
@@ -11,6 +11,8 @@
     "eidolon_repraised:polished_pressure_plate",
     "eidolon_repraised:polished_standing_sign",
     "eidolon_repraised:polished_wall_sign",
+    "eidolon_repraised:polished_hanging_sign",
+    "eidolon_repraised:polished_hanging_wall_sign",
     "eidolon_repraised:polished_wood_pillar",
     "eidolon_repraised:illwood_planks_fence_gate",
     "eidolon_repraised:illwood_planks_fence",
@@ -21,10 +23,13 @@
     "eidolon_repraised:illwood_pressure_plate",
     "eidolon_repraised:illwood_standing_sign",
     "eidolon_repraised:illwood_wall_sign",
+    "eidolon_repraised:illwood_hanging_sign",
+    "eidolon_repraised:illwood_hanging_wall_sign",
     "#eidolon_repraised:illwood_logs",
     "eidolon_repraised:wooden_altar",
     "eidolon_repraised:wooden_brewing_stand",
     "eidolon_repraised:worktable",
-    "eidolon_repraised:research_table"
+    "eidolon_repraised:research_table",
+    "eidolon_repraised:scriptorium"
   ]
 }


### PR DESCRIPTION
Fixed breaking mirecap, scriptorium, polished button, sign, pressure_plate yielded no drops.
Axes can break Scriptorium and Hanging Sign faster.
Fixed effect icon still displayed on the client after Purity Incense removed the effect.

--1.21.1 Only
Fixed Death Bane Incense and Gloom Incense had opposite effects on undead and non-undead mob.
Fixed Observer could not emit a redstone tick on Crucible step change.