### PR TITLE
[1.20.1] Fix some bugs

### DIFF
--- a/src/main/java/elucent/eidolon/common/incense/PurityIncense.java
+++ b/src/main/java/elucent/eidolon/common/incense/PurityIncense.java
@@ -5,6 +5,7 @@ import elucent.eidolon.client.particle.Particles;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.particles.ParticleTypes;
 import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.effect.MobEffectInstance;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.phys.AABB;
@@ -52,7 +53,11 @@ public class PurityIncense extends IncenseRitual {
             BlockPos pos = censer.getBlockPos();
             assert level != null;
             for (LivingEntity entity : level.getEntitiesOfClass(LivingEntity.class, new AABB(pos).inflate(range()))) {
-                entity.getActiveEffects().removeIf(effect -> !effect.getEffect().isBeneficial() && !effect.getEffect().getCurativeItems().isEmpty());
+                entity.getActiveEffects().stream()
+                        .filter(effect -> !effect.getEffect().isBeneficial() && !effect.getEffect().getCurativeItems().isEmpty())
+                        .map(MobEffectInstance::getEffect)
+                        .toList()
+                        .forEach(entity::removeEffect);
             }
         }
     }

--- a/src/main/resources/data/eidolon/loot_tables/blocks/mirecap.json
+++ b/src/main/resources/data/eidolon/loot_tables/blocks/mirecap.json
@@ -1,0 +1,43 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "rolls": 1.0,
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "eidolon:mirecap"
+        }
+      ]
+    },
+    {
+      "rolls": 1.0,
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "conditions": [
+            {
+              "condition": "minecraft:random_chance",
+              "chance": 0.5
+            }
+          ],
+          "name": "eidolon:mirecap"
+        }
+      ],
+      "conditions": [
+        {
+          "condition": "minecraft:block_state_property",
+          "block": "eidolon:mirecap",
+          "properties": {
+            "age": "3"
+          }
+        }
+      ]
+    }
+  ],
+  "functions": [
+    {
+      "function": "minecraft:explosion_decay"
+    }
+  ]
+}

--- a/src/main/resources/data/eidolon/loot_tables/blocks/polished_button.json
+++ b/src/main/resources/data/eidolon/loot_tables/blocks/polished_button.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "eidolon:polished_button"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ],
+  "random_sequence": "eidolon:blocks/polished_button"
+}

--- a/src/main/resources/data/eidolon/loot_tables/blocks/polished_hanging_sign.json
+++ b/src/main/resources/data/eidolon/loot_tables/blocks/polished_hanging_sign.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "eidolon:polished_hanging_sign"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ],
+  "random_sequence": "eidolon:blocks/polished_hanging_sign"
+}

--- a/src/main/resources/data/eidolon/loot_tables/blocks/polished_hanging_wall_sign.json
+++ b/src/main/resources/data/eidolon/loot_tables/blocks/polished_hanging_wall_sign.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "eidolon:polished_hanging_sign"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ],
+  "random_sequence": "eidolon:blocks/polished_hanging_wall_sign"
+}

--- a/src/main/resources/data/eidolon/loot_tables/blocks/polished_pressure_plate.json
+++ b/src/main/resources/data/eidolon/loot_tables/blocks/polished_pressure_plate.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "eidolon:polished_pressure_plate"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ],
+  "random_sequence": "eidolon:blocks/polished_pressure_plate"
+}

--- a/src/main/resources/data/eidolon/loot_tables/blocks/polished_standing_sign.json
+++ b/src/main/resources/data/eidolon/loot_tables/blocks/polished_standing_sign.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "eidolon:polished_sign"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ],
+  "random_sequence": "eidolon:blocks/polished_standing_sign"
+}

--- a/src/main/resources/data/eidolon/loot_tables/blocks/polished_wall_sign.json
+++ b/src/main/resources/data/eidolon/loot_tables/blocks/polished_wall_sign.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "eidolon:polished_sign"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ],
+  "random_sequence": "eidolon:blocks/polished_wall_sign"
+}

--- a/src/main/resources/data/eidolon/loot_tables/blocks/scriptorium.json
+++ b/src/main/resources/data/eidolon/loot_tables/blocks/scriptorium.json
@@ -1,0 +1,19 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "rolls": 1,
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "eidolon:scriptorium"
+        }
+      ],
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ]
+    }
+  ]
+}

--- a/src/main/resources/data/minecraft/tags/blocks/mineable/axe.json
+++ b/src/main/resources/data/minecraft/tags/blocks/mineable/axe.json
@@ -11,6 +11,8 @@
     "eidolon:polished_pressure_plate",
     "eidolon:polished_standing_sign",
     "eidolon:polished_wall_sign",
+    "eidolon:polished_hanging_sign",
+    "eidolon:polished_hanging_wall_sign",
     "eidolon:polished_wood_pillar",
     "eidolon:illwood_planks_fence_gate",
     "eidolon:illwood_planks_fence",
@@ -21,10 +23,13 @@
     "eidolon:illwood_pressure_plate",
     "eidolon:illwood_standing_sign",
     "eidolon:illwood_wall_sign",
+    "eidolon:illwood_hanging_sign",
+    "eidolon:illwood_hanging_wall_sign",
     "#eidolon:illwood_logs",
     "eidolon:wooden_altar",
     "eidolon:wooden_brewing_stand",
     "eidolon:worktable",
-    "eidolon:research_table"
+    "eidolon:research_table",
+    "eidolon:scriptorium"
   ]
 }


### PR DESCRIPTION
Fixed breaking mirecap, scriptorium, polished button, sign, pressure_plate yielded no drops.
Axes can break Scriptorium and Hanging Sign faster.
Fixed effect icon still displayed on the client after Purity Incense removed the effect.

--1.21.1 Only
Fixed Death Bane Incense and Gloom Incense had opposite effects on undead and non-undead mob.
Fixed Observer could not emit a redstone tick on Crucible step change.