### PR TITLE
[1.21.1] Improve particle precision at extreme coordinates

### DIFF
--- a/src/main/java/alexthw/eidolon_repraised/api/ritual/IncenseRitual.java
+++ b/src/main/java/alexthw/eidolon_repraised/api/ritual/IncenseRitual.java
@@ -77,7 +77,7 @@ public abstract class IncenseRitual {
     }
 
     public void animateParticles(int burnCounter, BlockPos blockPos, Level level) {
-        float x = blockPos.getX() + 0.5f, y = blockPos.getY() + 0.45f, z = blockPos.getZ() + 0.5f;
+        double x = blockPos.getX() + 0.5, y = blockPos.getY() + 0.45, z = blockPos.getZ() + 0.5;
         float r = getRed();
         float g = getGreen();
         float b = getBlue();

--- a/src/main/java/alexthw/eidolon_repraised/common/entity/NecromancerEntity.java
+++ b/src/main/java/alexthw/eidolon_repraised/common/entity/NecromancerEntity.java
@@ -80,8 +80,8 @@ public class NecromancerEntity extends SpellcasterIllager {
         if (level().isClientSide && this.isCastingSpell()) {
             IllagerSpell spelltype = getCurrentSpell();
             float f = this.yBodyRot * ((float) Math.PI / 180F) + Mth.cos((float) this.tickCount * 0.6662F) * 0.25F;
-            float f1 = Mth.cos(f);
-            float f2 = Mth.sin(f);
+            double f1 = Mth.cos(f);
+            double f2 = Mth.sin(f);
             if (spelltype == IllagerSpell.FANGS) {
                 Particles.create(EidolonParticles.SPARKLE_PARTICLE.get())
                         .setColor(1, 0.3125f, 0.375f, 0.75f, 0.375f, 1)

--- a/src/main/java/alexthw/eidolon_repraised/common/incense/PrayerIncense.java
+++ b/src/main/java/alexthw/eidolon_repraised/common/incense/PrayerIncense.java
@@ -67,7 +67,7 @@ public class PrayerIncense extends IncenseRitual {
 
     @Override
     public void animateParticles(int burnCounter, BlockPos blockPos, Level level) {
-        float x = blockPos.getX() + 0.5f, y = blockPos.getY() + 0.45f, z = blockPos.getZ() + 0.5f;
+        double x = blockPos.getX() + 0.5, y = blockPos.getY() + 0.45, z = blockPos.getZ() + 0.5;
         float r = getRed();
         float g = getGreen();
         float b = getBlue();

--- a/src/main/java/alexthw/eidolon_repraised/common/spell/PrayerSpell.java
+++ b/src/main/java/alexthw/eidolon_repraised/common/spell/PrayerSpell.java
@@ -132,23 +132,23 @@ public class PrayerSpell extends StaticSpell {
         BlockState state = world.getBlockState(effigy.getBlockPos());
         Direction dir = state.getValue(HorizontalBlockBase.HORIZONTAL_FACING);
         Direction tangent = dir.getClockWise();
-        float x = effigy.getBlockPos().getX() + 0.5f + dir.getStepX() * 0.21875f;
-        float y = effigy.getBlockPos().getY() + 0.8125f;
-        float z = effigy.getBlockPos().getZ() + 0.5f + dir.getStepZ() * 0.21875f;
+        double x = effigy.getBlockPos().getX() + 0.5 + dir.getStepX() * 0.21875;
+        double y = effigy.getBlockPos().getY() + 0.8125;
+        double z = effigy.getBlockPos().getZ() + 0.5 + dir.getStepZ() * 0.21875;
         Particles.create(FLAME_PARTICLE.get())
                 .setColor(color.getRed(), color.getGreen(), color.getBlue())
                 .setAlpha(0.5f, 0)
                 .setScale(0.125f, 0.0625f)
                 .randomOffset(0.01f)
                 .randomVelocity(0.0025f).addVelocity(0, 0.005f, 0)
-                .repeat(world, x + 0.09375f * tangent.getStepX(), y, z + 0.09375f * tangent.getStepZ(), 8);
+                .repeat(world, x + 0.09375 * tangent.getStepX(), y, z + 0.09375 * tangent.getStepZ(), 8);
         Particles.create(FLAME_PARTICLE.get())
                 .setColor(color.getRed(), color.getGreen(), color.getBlue())
                 .setAlpha(0.5f, 0)
                 .setScale(0.1875f, 0.125f)
                 .randomOffset(0.01f)
                 .randomVelocity(0.0025f).addVelocity(0, 0.005f, 0)
-                .repeat(world, x - 0.09375f * tangent.getStepX(), y, z - 0.09375f * tangent.getStepZ(), 8);
+                .repeat(world, x - 0.09375 * tangent.getStepX(), y, z - 0.09375 * tangent.getStepZ(), 8);
     }
 
     @Override

--- a/src/main/java/alexthw/eidolon_repraised/common/tile/BrazierTileEntity.java
+++ b/src/main/java/alexthw/eidolon_repraised/common/tile/BrazierTileEntity.java
@@ -187,9 +187,9 @@ public class BrazierTileEntity extends SingleItemTile implements IBurner, Recipe
                 float angle = progress * (float) Math.PI / 4 + i * (float) Math.PI / 4;
                 float radius = 0.625f * Mth.sin(4 * angle);
                 angle += (float) Math.PI / 4;
-                float x = getBlockPos().getX() + 0.5f + Mth.sin(angle) * radius;
-                float y = getBlockPos().getY() + 0.875f;
-                float z = getBlockPos().getZ() + 0.5f + Mth.cos(angle) * radius;
+                double x = getBlockPos().getX() + 0.5 + Mth.sin(angle) * radius;
+                double y = getBlockPos().getY() + 0.875;
+                double z = getBlockPos().getZ() + 0.5 + Mth.cos(angle) * radius;
                 Particles.create(EidolonParticles.WISP_PARTICLE.get())
                         .setAlpha(0.25f * progress, 0).setScale(0.125f, 0.0625f).setLifetime(20)
                         .setColor(1.0f, 0.5f, 0.25f, 1.0f, 0.25f, 0.375f)
@@ -228,7 +228,7 @@ public class BrazierTileEntity extends SingleItemTile implements IBurner, Recipe
             if (ritual.tick(level, worldPosition) == RitualResult.TERMINATE) complete();
         }
         if (level.isClientSide && burning) {
-            float x = getBlockPos().getX() + 0.5f, y = getBlockPos().getY() + 1, z = getBlockPos().getZ() + 0.5f;
+            double x = getBlockPos().getX() + 0.5, y = getBlockPos().getY() + 1.0, z = getBlockPos().getZ() + 0.5;
             float r = ritual == null ? 1.0f : ritual.getRed();
             float g = ritual == null ? 0.5f : ritual.getGreen();
             float b = ritual == null ? 0.25f : ritual.getBlue();

--- a/src/main/java/alexthw/eidolon_repraised/network/DeathbringerSlashEffectPacket.java
+++ b/src/main/java/alexthw/eidolon_repraised/network/DeathbringerSlashEffectPacket.java
@@ -23,18 +23,18 @@ public class DeathbringerSlashEffectPacket extends AbstractPacket {
             DeathbringerSlashEffectPacket::decode
     );
 
-    final float x1;
-    final float y1;
-    final float z1;
-    final float x2;
-    final float y2;
-    final float z2;
+    final double x1;
+    final double y1;
+    final double z1;
+    final double x2;
+    final double y2;
+    final double z2;
     final int c1;
     final int c2;
     final int c3;
     final int c4;
 
-    public DeathbringerSlashEffectPacket(float x1, float y1, float z1, float x2, float y2, float z2, int color1, int color2, int color3, int color4) {
+    public DeathbringerSlashEffectPacket(double x1, double y1, double z1, double x2, double y2, double z2, int color1, int color2, int color3, int color4) {
         this.x1 = x1;
         this.y1 = y1;
         this.z1 = z1;
@@ -48,13 +48,15 @@ public class DeathbringerSlashEffectPacket extends AbstractPacket {
     }
 
     public static void encode(DeathbringerSlashEffectPacket object, FriendlyByteBuf buffer) {
-        buffer.writeFloat(object.x1).writeFloat(object.y1).writeFloat(object.z1);
-        buffer.writeFloat(object.x2).writeFloat(object.y2).writeFloat(object.z2);
+        buffer.writeDouble(object.x1).writeDouble(object.y1).writeDouble(object.z1);
+        buffer.writeDouble(object.x2).writeDouble(object.y2).writeDouble(object.z2);
         buffer.writeInt(object.c1).writeInt(object.c2).writeInt(object.c3).writeInt(object.c4);
     }
 
     public static DeathbringerSlashEffectPacket decode(FriendlyByteBuf buffer) {
-        return new DeathbringerSlashEffectPacket(buffer.readFloat(), buffer.readFloat(), buffer.readFloat(), buffer.readFloat(), buffer.readFloat(), buffer.readFloat(),
+        return new DeathbringerSlashEffectPacket(
+                buffer.readDouble(), buffer.readDouble(), buffer.readDouble(),
+                buffer.readDouble(), buffer.readDouble(), buffer.readDouble(),
                 buffer.readInt(), buffer.readInt(), buffer.readInt(), buffer.readInt());
     }
 

--- a/src/main/java/alexthw/eidolon_repraised/network/FeatherEffectPacket.java
+++ b/src/main/java/alexthw/eidolon_repraised/network/FeatherEffectPacket.java
@@ -17,32 +17,32 @@ public class FeatherEffectPacket extends AbstractPacket {
 
     public static final Type<FeatherEffectPacket> TYPE = new Type<>(Eidolon.prefix("feather_effect"));
     public static final StreamCodec<FriendlyByteBuf, FeatherEffectPacket> CODEC = StreamCodec.composite(
-            ByteBufCodecs.FLOAT, p -> p.x,
-            ByteBufCodecs.FLOAT, p -> p.y,
-            ByteBufCodecs.FLOAT, p -> p.z,
+            ByteBufCodecs.DOUBLE, p -> p.x,
+            ByteBufCodecs.DOUBLE, p -> p.y,
+            ByteBufCodecs.DOUBLE, p -> p.z,
             FeatherEffectPacket::new
     );
 
-    final float x;
-    final float y;
-    final float z;
+    final double x;
+    final double y;
+    final double z;
 
     public FeatherEffectPacket(BlockPos pos) {
         this(pos.getX() + 0.5, pos.getY() + 0.5, pos.getZ() + 0.5);
     }
 
     public FeatherEffectPacket(double x, double y, double z) {
-        this.x = (float) x;
-        this.y = (float) y;
-        this.z = (float) z;
+        this.x = x;
+        this.y = y;
+        this.z = z;
     }
 
     public static void encode(FeatherEffectPacket object, FriendlyByteBuf buffer) {
-        buffer.writeFloat(object.x).writeFloat(object.y).writeFloat(object.z);
+        buffer.writeDouble(object.x).writeDouble(object.y).writeDouble(object.z);
     }
 
     public static FeatherEffectPacket decode(FriendlyByteBuf buffer) {
-        return new FeatherEffectPacket(buffer.readFloat(), buffer.readFloat(), buffer.readFloat());
+        return new FeatherEffectPacket(buffer.readDouble(), buffer.readDouble(), buffer.readDouble());
     }
 
     @Override

--- a/src/main/java/alexthw/eidolon_repraised/network/MagicBurstEffectPacket.java
+++ b/src/main/java/alexthw/eidolon_repraised/network/MagicBurstEffectPacket.java
@@ -18,11 +18,11 @@ public class MagicBurstEffectPacket extends AbstractPacket {
     public static final Type<MagicBurstEffectPacket> TYPE = new Type<>(Eidolon.prefix("magic_burst_effect"));
 
     public static final StreamCodec<RegistryFriendlyByteBuf, MagicBurstEffectPacket> CODEC = StreamCodec.composite(
-            ByteBufCodecs.FLOAT,
+            ByteBufCodecs.DOUBLE,
             pkt -> pkt.x,
-            ByteBufCodecs.FLOAT,
+            ByteBufCodecs.DOUBLE,
             pkt -> pkt.y,
-            ByteBufCodecs.FLOAT,
+            ByteBufCodecs.DOUBLE,
             pkt -> pkt.z,
             ByteBufCodecs.INT,
             pkt -> pkt.c1,
@@ -31,9 +31,9 @@ public class MagicBurstEffectPacket extends AbstractPacket {
             MagicBurstEffectPacket::new
     );
 
-    final float x;
-    final float y;
-    final float z;
+    final double x;
+    final double y;
+    final double z;
     final int c1;
     final int c2;
 
@@ -42,20 +42,20 @@ public class MagicBurstEffectPacket extends AbstractPacket {
     }
 
     public MagicBurstEffectPacket(double x, double y, double z, int color1, int color2) {
-        this.x = (float) x;
-        this.y = (float) y;
-        this.z = (float) z;
+        this.x = x;
+        this.y = y;
+        this.z = z;
         this.c1 = color1;
         this.c2 = color2;
     }
 
     public static void encode(MagicBurstEffectPacket object, FriendlyByteBuf buffer) {
-        buffer.writeFloat(object.x).writeFloat(object.y).writeFloat(object.z);
+        buffer.writeDouble(object.x).writeDouble(object.y).writeDouble(object.z);
         buffer.writeInt(object.c1).writeInt(object.c2);
     }
 
     public static MagicBurstEffectPacket decode(FriendlyByteBuf buffer) {
-        return new MagicBurstEffectPacket(buffer.readFloat(), buffer.readFloat(), buffer.readFloat(), buffer.readInt(), buffer.readInt());
+        return new MagicBurstEffectPacket(buffer.readDouble(), buffer.readDouble(), buffer.readDouble(), buffer.readInt(), buffer.readInt());
     }
 
     @Override


### PR DESCRIPTION
This fixes a number of places where the worldspace particle positions are stored or converted to floats rather than doubles; this causes the effects to render at incorrect locations when extremely far from 0,0, due to precision issues.*

The main ones I noticed were the brazier and effigy eye particles, but I also fixed the other locations.  This ends up changing the network protocol, to increase the precision of coordinates used for the effect packets; this can be reverted if needed.

*(This isn't usually relevant, but I have a local patch for support for [Sable](https://github.com/ryanhcode/sable) and [Create Aeronautics](https://github.com/Creators-of-Aeronautics/Simulated-Project), which place ships 2048000 blocks out in the overworld.)