### PR TITLE
[1.21.1] Improve spell failure messages

### DIFF
--- a/src/main/java/alexthw/eidolon_repraised/common/spell/AnimalSacrificeSpell.java
+++ b/src/main/java/alexthw/eidolon_repraised/common/spell/AnimalSacrificeSpell.java
@@ -28,12 +28,20 @@ public class AnimalSacrificeSpell extends PrayerSpell {
         if (reputationCheck(world, player, 3.0)) return false;
         EffigyTileEntity effigy = getEffigy(world, pos);
         GobletTileEntity goblet = getGoblet(world, pos);
-        if (effigy == null || goblet == null || goblet.getEntityType() == null) {
+        if (effigy == null) {
             player.displayClientMessage(Component.translatable("eidolon_repraised.message.no_effigy"), true);
             return false;
         }
-        Entity test = goblet.getEntityType().create(world);
-        return test instanceof Animal && effigy.ready();
+        if (goblet == null) {
+            player.displayClientMessage(Component.translatable("eidolon_repraised.message.no_goblet"), true);
+            return false;
+        }
+        boolean validSacrifice = goblet.getEntityType() != null && goblet.getEntityType().create(world) instanceof Animal;
+        if (!validSacrifice) {
+            player.displayClientMessage(Component.translatable("eidolon_repraised.message.inadequate_sacrifice"), true);
+            return false;
+        }
+        return effigy.ready();
     }
 
     @Override

--- a/src/main/java/alexthw/eidolon_repraised/common/spell/ApplyPotionSpell.java
+++ b/src/main/java/alexthw/eidolon_repraised/common/spell/ApplyPotionSpell.java
@@ -3,6 +3,7 @@ package alexthw.eidolon_repraised.common.spell;
 import alexthw.eidolon_repraised.api.spells.Sign;
 import net.minecraft.core.BlockPos;
 import net.minecraft.resources.ResourceLocation;
+import net.minecraft.network.chat.Component;
 import net.minecraft.world.effect.MobEffectInstance;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.ai.attributes.Attributes;
@@ -18,7 +19,12 @@ public abstract class ApplyPotionSpell extends StaticSpell {
 
     @Override
     public boolean canCast(Level world, BlockPos pos, Player player) {
-        return rayTrace(player, player.getAttributeValue(Attributes.BLOCK_INTERACTION_RANGE), 0, true) instanceof EntityHitResult result && result.getEntity() instanceof LivingEntity;
+        HitResult raytrace = rayTrace(player, player.getAttributeValue(Attributes.BLOCK_INTERACTION_RANGE), 0, true);
+        if (raytrace instanceof EntityHitResult result && result.getEntity() instanceof LivingEntity) {
+            return true;
+        }
+        player.displayClientMessage(Component.translatable("eidolon_repraised.message.no_target"), true);
+        return false;
     }
 
     @Override

--- a/src/main/java/alexthw/eidolon_repraised/common/spell/ConvertZombieSpell.java
+++ b/src/main/java/alexthw/eidolon_repraised/common/spell/ConvertZombieSpell.java
@@ -31,17 +31,23 @@ public class ConvertZombieSpell extends PrayerSpell {
 
     @Override
     public boolean canCast(Level world, BlockPos pos, Player player) {
-        HitResult ray = rayTrace(player, player.getAttributeValue(Attributes.BLOCK_INTERACTION_RANGE), 0, true);
-        boolean flag = ray instanceof EntityHitResult result && result.getEntity() instanceof ZombieVillager;
         EffigyTileEntity effigy = getEffigy(world, pos);
         if (effigy == null) {
             player.displayClientMessage(Component.translatable("eidolon_repraised.message.no_effigy"), true);
             return false;
         }
         AltarInfo info = AltarInfo.getAltarInfo(world, effigy.getBlockPos());
-        if (info.getAltar() == null || !info.getAltar().defaultBlockState().is(Registry.BETTER_ALTAR_BLOCKS) || info.getIcon() != Registry.ELDER_EFFIGY.get())
+        if (info.getAltar() == null || !info.getAltar().defaultBlockState().is(Registry.BETTER_ALTAR_BLOCKS) || info.getIcon() != Registry.ELDER_EFFIGY.get()) {
+            player.displayClientMessage(Component.translatable("eidolon_repraised.message.inadequate_altar"), true);
             return false;
-        return flag && super.canCast(world, pos, player);
+        }
+        HitResult ray = rayTrace(player, player.getAttributeValue(Attributes.BLOCK_INTERACTION_RANGE), 0, true);
+        boolean validTarget = ray instanceof EntityHitResult result && result.getEntity() instanceof ZombieVillager;
+        if (!validTarget) {
+            player.displayClientMessage(Component.translatable("eidolon_repraised.message.no_target"), true);
+            return false;
+        }
+        return super.canCast(world, pos, player);
     }
 
     @Override

--- a/src/main/java/alexthw/eidolon_repraised/common/spell/DarkTouchSpell.java
+++ b/src/main/java/alexthw/eidolon_repraised/common/spell/DarkTouchSpell.java
@@ -69,9 +69,14 @@ public class DarkTouchSpell extends StaticSpell {
 
         Vec3 v = getVector(world, player);
         List<ItemEntity> items = world.getEntitiesOfClass(ItemEntity.class, new AABB(v.x - 1.5, v.y - 1.5, v.z - 1.5, v.x + 1.5, v.y + 1.5, v.z + 1.5));
-        if (items.size() != 1) return false;
-        ItemStack stack = items.getFirst().getItem();
-        return canTouch(stack, world, player);
+        if (items.size() == 1) {
+            ItemStack stack = items.getFirst().getItem();
+            if (canTouch(stack, world, player)) {
+                return true;
+            }
+        }
+        player.displayClientMessage(Component.translatable("eidolon_repraised.message.no_target"), true);
+        return false;
     }
 
     boolean canTouch(ItemStack stack, Level world, Player player) {

--- a/src/main/java/alexthw/eidolon_repraised/common/spell/FireTouchSpell.java
+++ b/src/main/java/alexthw/eidolon_repraised/common/spell/FireTouchSpell.java
@@ -8,6 +8,7 @@ import alexthw.eidolon_repraised.network.Networking;
 import alexthw.eidolon_repraised.registries.Researches;
 import alexthw.eidolon_repraised.util.KnowledgeUtil;
 import net.minecraft.core.BlockPos;
+import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.sounds.SoundEvents;
 import net.minecraft.sounds.SoundSource;
@@ -41,11 +42,15 @@ public class FireTouchSpell extends StaticSpell {
             BlockState hitState = world.getBlockState(rayTraceResult.getBlockPos());
             if (hitState.getBlock() instanceof CandleBlock && CandleBlock.canLight(hitState) || hitState.getBlock() instanceof CampfireBlock && CampfireBlock.canLight(hitState)) {
                 return true;
-            } else if (world.getBlockEntity(rayTraceResult.getBlockPos()) instanceof IBurner brazier) {
-                return brazier.canStartBurning();
+            } else if (world.getBlockEntity(rayTraceResult.getBlockPos()) instanceof IBurner brazier && brazier.canStartBurning()) {
+                return true;
             }
         }
-        return ray instanceof EntityHitResult;
+        if (ray instanceof EntityHitResult) {
+            return true;
+        }
+        player.displayClientMessage(Component.translatable("eidolon_repraised.message.no_target"), true);
+        return false;
     }
 
     @Override

--- a/src/main/java/alexthw/eidolon_repraised/common/spell/FrostSpell.java
+++ b/src/main/java/alexthw/eidolon_repraised/common/spell/FrostSpell.java
@@ -6,6 +6,7 @@ import alexthw.eidolon_repraised.registries.EidolonPotions;
 import alexthw.eidolon_repraised.registries.Researches;
 import alexthw.eidolon_repraised.util.KnowledgeUtil;
 import net.minecraft.core.BlockPos;
+import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.sounds.SoundEvents;
 import net.minecraft.sounds.SoundSource;
@@ -36,7 +37,11 @@ public class FrostSpell extends StaticSpell {
                 return true;
             }
         }
-        return ray instanceof EntityHitResult;
+        if (ray instanceof EntityHitResult) {
+            return true;
+        }
+        player.displayClientMessage(Component.translatable("eidolon_repraised.message.no_target"), true);
+        return false;
     }
 
     @Override

--- a/src/main/java/alexthw/eidolon_repraised/common/spell/LightTouchSpell.java
+++ b/src/main/java/alexthw/eidolon_repraised/common/spell/LightTouchSpell.java
@@ -77,9 +77,14 @@ public class LightTouchSpell extends DarkTouchSpell {
 
         Vec3 v = getVector(world, player);
         List<ItemEntity> items = world.getEntitiesOfClass(ItemEntity.class, new AABB(v.x - 1.5, v.y - 1.5, v.z - 1.5, v.x + 1.5, v.y + 1.5, v.z + 1.5));
-        if (items.size() != 1) return false;
-        ItemStack stack = items.getFirst().getItem();
-        return canTouch(stack, world, player);
+        if (items.size() == 1) {
+            ItemStack stack = items.getFirst().getItem();
+            if (canTouch(stack, world, player)) {
+                return true;
+            }
+        }
+        player.displayClientMessage(Component.translatable("eidolon_repraised.message.no_target"), true);
+        return false;
     }
 
     @Override

--- a/src/main/java/alexthw/eidolon_repraised/common/spell/PrayerSpell.java
+++ b/src/main/java/alexthw/eidolon_repraised/common/spell/PrayerSpell.java
@@ -65,7 +65,11 @@ public class PrayerSpell extends StaticSpell {
     public boolean canCast(Level world, BlockPos pos, Player player) {
         if (reputationCheck(world, player, 0)) return false;
         EffigyTileEntity effigy = getEffigy(world, pos);
-        return effigy != null && effigy.ready();
+        if (effigy == null) {
+            player.displayClientMessage(Component.translatable("eidolon_repraised.message.no_effigy"), true);
+            return false;
+        }
+        return effigy.ready();
     }
 
     public static void updateMagic(AltarInfo altarInfo, Player player, Level world, double reputation) {

--- a/src/main/java/alexthw/eidolon_repraised/common/spell/SmiteSpell.java
+++ b/src/main/java/alexthw/eidolon_repraised/common/spell/SmiteSpell.java
@@ -4,6 +4,7 @@ import alexthw.eidolon_repraised.api.spells.Sign;
 import alexthw.eidolon_repraised.common.deity.DeityLocks;
 import alexthw.eidolon_repraised.util.KnowledgeUtil;
 import net.minecraft.core.BlockPos;
+import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.tags.EntityTypeTags;
@@ -29,7 +30,7 @@ public class SmiteSpell extends StaticSpell {
         if (ray instanceof EntityHitResult entityHitResult && entityHitResult.getEntity() instanceof LivingEntity livingEntity) {
             return livingEntity.getType().is(EntityTypeTags.UNDEAD);
         }
-
+        player.displayClientMessage(Component.translatable("eidolon_repraised.message.no_target"), true);
         return false;
     }
 

--- a/src/main/java/alexthw/eidolon_repraised/common/spell/ThrallSpell.java
+++ b/src/main/java/alexthw/eidolon_repraised/common/spell/ThrallSpell.java
@@ -38,8 +38,12 @@ public class ThrallSpell extends StaticSpell {
     public boolean canCast(Level world, BlockPos pos, Player player) {
         HitResult ray = rayTrace(player, player.getAttributeValue(Attributes.BLOCK_INTERACTION_RANGE) + 3, 0, false);
         if (ray instanceof EntityHitResult result && result.getEntity() instanceof LivingEntity living) {
-            return living.getType().is(ENTHRALL_WHITELIST) || living.getType().is(EntityTypeTags.UNDEAD) && !living.getType().is(ENTHRALL_BLACKLIST);
+            var entityType = living.getType();
+            if (entityType.is(ENTHRALL_WHITELIST) || entityType.is(EntityTypeTags.UNDEAD) && !entityType.is(ENTHRALL_BLACKLIST)) {
+                return true;
+            }
         }
+        player.displayClientMessage(Component.translatable("eidolon_repraised.message.no_target"), true);
         return false;
     }
 

--- a/src/main/java/alexthw/eidolon_repraised/common/spell/UndeadLureSpell.java
+++ b/src/main/java/alexthw/eidolon_repraised/common/spell/UndeadLureSpell.java
@@ -2,6 +2,7 @@ package alexthw.eidolon_repraised.common.spell;
 
 import alexthw.eidolon_repraised.api.spells.Sign;
 import net.minecraft.core.BlockPos;
+import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.entity.ai.attributes.Attributes;
 import net.minecraft.world.entity.player.Player;
@@ -17,7 +18,11 @@ public class UndeadLureSpell extends StaticSpell {
     @Override
     public boolean canCast(Level world, BlockPos pos, Player player) {
         HitResult ray = rayTrace(player, player.getAttributeValue(Attributes.BLOCK_INTERACTION_RANGE), 0, true);
-        return ray instanceof BlockHitResult;
+        if (ray instanceof BlockHitResult) {
+            return true;
+        }
+        player.displayClientMessage(Component.translatable("eidolon_repraised.message.no_target"), true);
+        return false;
     }
 
     @Override

--- a/src/main/java/alexthw/eidolon_repraised/common/spell/VillagerSacrificeSpell.java
+++ b/src/main/java/alexthw/eidolon_repraised/common/spell/VillagerSacrificeSpell.java
@@ -28,14 +28,30 @@ public class VillagerSacrificeSpell extends PrayerSpell {
         if (reputationCheck(world, player, 15)) return false;
         EffigyTileEntity effigy = getEffigy(world, pos);
         GobletTileEntity goblet = getGoblet(world, pos);
-        if (effigy == null || goblet == null || goblet.getEntityType() == null) {
+        if (effigy == null) {
             player.displayClientMessage(Component.translatable("eidolon_repraised.message.no_effigy"), true);
             return false;
         }
-        AltarInfo info = AltarInfo.getAltarInfo(world, effigy.getBlockPos());
-        if (info.getAltar() == null || !info.getAltar().defaultBlockState().is(Registry.BETTER_ALTAR_BLOCKS) || info.getIcon() != Registry.ELDER_EFFIGY.get())
+        if (goblet == null) {
+            player.displayClientMessage(Component.translatable("eidolon_repraised.message.no_goblet"), true);
             return false;
-        return (goblet.getEntityType() == EntityType.PLAYER || goblet.getEntityType().create(world) instanceof AbstractVillager) && effigy.ready();
+        }
+
+        AltarInfo info = AltarInfo.getAltarInfo(world, effigy.getBlockPos());
+        if (info.getAltar() == null || !info.getAltar().defaultBlockState().is(Registry.BETTER_ALTAR_BLOCKS) || info.getIcon() != Registry.ELDER_EFFIGY.get()) {
+            player.displayClientMessage(Component.translatable("eidolon_repraised.message.inadequate_altar"), true);
+            return false;
+        }
+
+        boolean validSacrifice = goblet.getEntityType() != null && (
+            goblet.getEntityType() == EntityType.PLAYER ||
+            goblet.getEntityType().create(world) instanceof AbstractVillager
+        );
+        if (!validSacrifice) {
+            player.displayClientMessage(Component.translatable("eidolon_repraised.message.inadequate_sacrifice"), true);
+            return false;
+        }
+        return effigy.ready();
     }
 
     @Override

--- a/src/main/java/alexthw/eidolon_repraised/common/spell/ZombifySpell.java
+++ b/src/main/java/alexthw/eidolon_repraised/common/spell/ZombifySpell.java
@@ -37,17 +37,23 @@ public class ZombifySpell extends PrayerSpell {
 
     @Override
     public boolean canCast(Level world, BlockPos pos, Player player) {
-        HitResult ray = rayTrace(player, player.getAttributeValue(Attributes.BLOCK_INTERACTION_RANGE), 0, true);
-        boolean flag = ray instanceof EntityHitResult result && result.getEntity() instanceof Villager;
         EffigyTileEntity effigy = getEffigy(world, pos);
         if (effigy == null) {
             player.displayClientMessage(Component.translatable("eidolon_repraised.message.no_effigy"), true);
             return false;
         }
         AltarInfo info = AltarInfo.getAltarInfo(world, effigy.getBlockPos());
-        if (info.getAltar() == null || !info.getAltar().defaultBlockState().is(Registry.BETTER_ALTAR_BLOCKS) || info.getIcon() != Registry.ELDER_EFFIGY.get())
+        if (info.getAltar() == null || !info.getAltar().defaultBlockState().is(Registry.BETTER_ALTAR_BLOCKS) || info.getIcon() != Registry.ELDER_EFFIGY.get()) {
+            player.displayClientMessage(Component.translatable("eidolon_repraised.message.inadequate_altar"), true);
             return false;
-        return flag && super.canCast(world, pos, player);
+        }
+        HitResult ray = rayTrace(player, player.getAttributeValue(Attributes.BLOCK_INTERACTION_RANGE), 0, true);
+        boolean validTarget = ray instanceof EntityHitResult result && result.getEntity() instanceof Villager;
+        if (!validTarget) {
+            player.displayClientMessage(Component.translatable("eidolon_repraised.message.no_target"), true);
+            return false;
+        }
+        return super.canCast(world, pos, player);
     }
 
     @Override

--- a/src/main/resources/assets/eidolon_repraised/lang/en_us.json
+++ b/src/main/resources/assets/eidolon_repraised/lang/en_us.json
@@ -810,7 +810,13 @@
   "commands.eidolon_repraised.reputation.success.multiple": "Updated Reputation of %s players",
   "eidolon_repraised.message.prayer_cooldown": "You should wait before using this prayer again.",
   "eidolon_repraised.message.not_enough_reputation": "Your prayer echoes without answers.",
-  "eidolon_repraised.message.no_effigy": "No Effigy nearby was found.",
+  "eidolon_repraised.message.max_reputation": "This patron has nothing else for you, aside mana",
+  "eidolon_repraised.message.reputation_locked": "This patron won't be appeased until you use your new knowledge",
+  "eidolon_repraised.message.no_effigy": "No Effigy was found nearby.",
+  "eidolon_repraised.message.no_goblet": "No Goblet was found nearby.",
+  "eidolon_repraised.message.no_target": "No target for this spell.",
+  "eidolon_repraised.message.inadequate_altar": "An improved altar is required.",
+  "eidolon_repraised.message.inadequate_sacrifice": "A sacrifice is required.",
   "eidolon_repraised.jei.health_sacrifice": "Sacrifice %d hearts.",
   "eidolon_repraised.angels_sight.mode.0": "The arrows will target the nearest entity.",
   "eidolon_repraised.angels_sight.mode.1": "The arrows will ignore players.",
@@ -900,7 +906,5 @@
   "eidolon_repraised.ritual.recharging_soulfire": "Recharging Soulfire",
   "eidolon_repraised.ritual.recharging_chill": "Recharging Bonechill",
   "key.eidolon_repraised.open_docs": "Open Codex",
-  "key.categories.eidolon_repraised": "Eidolon:Repraised",
-  "eidolon_repraised.message.max_reputation": "This patron has nothing else for you, aside mana",
-  "eidolon_repraised.message.reputation_locked": "This patron won't be appeased until you use your new knowledge"
+  "key.categories.eidolon_repraised": "Eidolon:Repraised"
 }


### PR DESCRIPTION
This makes the spell failure messages a bit more specific; it adds three new messages:
- `eidolon_repraised.message.no_goblet`, for when a spell requires a goblet but couldn't find it
- `eidolon_repraised.message.no_target`, for when a spell fails due to lack of a targetted block/entity
- `eidolon_repraised.message.inadequate_altar`, for when a spell requires an upgraded altar
- `eidolon_repraised.message.inadequate_sacrifice`, for when a spell requires a goblet sacrifice but was missing one or given one of the wrong type.

Doing this required restructuring the canCast requirements for each spell, but the logic should be the exact same.