### PR TITLE
[1.21.1] Attempt to fix the priest barter AI; still has minor issues

### DIFF
--- a/src/main/java/alexthw/eidolon_repraised/common/entity/ai/GenericBarterGoal.java
+++ b/src/main/java/alexthw/eidolon_repraised/common/entity/ai/GenericBarterGoal.java
@@ -21,7 +21,7 @@ import java.util.function.Predicate;
 
 public class GenericBarterGoal<E extends PathfinderMob> extends Goal {
     static final Random rand = new Random();
-    static final int WAIT_TIME = 50; // Roughly 5 seconds
+    static final int WAIT_TIME = 50; // Roughly 2,5 seconds
 
     final Predicate<ItemStack> valid;
     final Function<ItemStack, ItemStack> result;
@@ -57,7 +57,7 @@ public class GenericBarterGoal<E extends PathfinderMob> extends Goal {
             (item) -> valid.test(item.getItem())
         );
         if (items.isEmpty()) return false;
-        targetItem = items.get(0);
+        targetItem = items.getFirst();
         return targetItem != null && targetItem.isAlive();
     }
 

--- a/src/main/java/alexthw/eidolon_repraised/common/entity/ai/GenericBarterGoal.java
+++ b/src/main/java/alexthw/eidolon_repraised/common/entity/ai/GenericBarterGoal.java
@@ -1,5 +1,6 @@
 package alexthw.eidolon_repraised.common.entity.ai;
 
+import alexthw.eidolon_repraised.Eidolon;
 import net.minecraft.sounds.SoundEvents;
 import net.minecraft.sounds.SoundSource;
 import net.minecraft.world.InteractionHand;
@@ -9,6 +10,7 @@ import net.minecraft.world.entity.ai.goal.Goal;
 import net.minecraft.world.entity.item.ItemEntity;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.phys.AABB;
+import net.minecraft.world.phys.Vec3;
 
 import java.util.Comparator;
 import java.util.EnumSet;
@@ -18,36 +20,26 @@ import java.util.function.Function;
 import java.util.function.Predicate;
 
 public class GenericBarterGoal<E extends PathfinderMob> extends Goal {
-
     static final Random rand = new Random();
+    static final int WAIT_TIME = 50; // Roughly 5 seconds
+
     final Predicate<ItemStack> valid;
     final Function<ItemStack, ItemStack> result;
-    int progress = 0, cooldown = 0, lastTick = 0;
-    final E entity;
-    ItemStack backupHack = ItemStack.EMPTY;
+    final float speed;
 
-    public GenericBarterGoal(E entity, Predicate<ItemStack> valid, Function<ItemStack, ItemStack> result) {
+    final E entity;
+    ItemEntity targetItem;
+    ItemStack heldItem;
+    ItemStack previousHeld;
+
+    int pickupCooldown = 0;
+
+    public GenericBarterGoal(E entity, Predicate<ItemStack> valid, Function<ItemStack, ItemStack> result, float speed) {
         this.entity = entity;
         this.valid = valid;
         this.result = result;
+        this.speed = speed;
         this.setFlags(EnumSet.of(Flag.MOVE, Flag.TARGET));
-    }
-
-    @Override
-    public void stop() {
-        // If the goal is stopped while in the middle of a barter, make sure the held item isn't lost.
-        if (progress > 0) {
-            ItemStack held = entity.getMainHandItem();
-            if (!held.isEmpty() && !entity.level().isClientSide) {
-                // drop the held item back into the world so it isn't lost
-                entity.level().addFreshEntity(new ItemEntity(entity.level(), entity.getX(), entity.getY() + 0.1, entity.getZ(), held.copy()));
-            }
-            // restore previous held stack (if any)
-            entity.setItemInHand(InteractionHand.MAIN_HAND, !backupHack.isEmpty() ? backupHack.copy() : ItemStack.EMPTY);
-            backupHack = ItemStack.EMPTY;
-            progress = 0;
-            cooldown = 600;
-        }
     }
 
     @Override
@@ -56,57 +48,98 @@ public class GenericBarterGoal<E extends PathfinderMob> extends Goal {
     }
 
     @Override
-    public void tick() {
-        if (cooldown > 0) return;
-
-        entity.setTarget(null);
-        if (progress > 0) {
-            // performing barter countdown
-            progress--;
-            entity.getNavigation().stop();
-            if (progress == 0) {
-                if (!entity.level().isClientSide) {
-                    // spawn the result based on the item we were holding during barter
-                    ItemStack held = entity.getMainHandItem().copy();
-                    entity.level().addFreshEntity(new ItemEntity(entity.level(), entity.getX(), entity.getY() + 0.1, entity.getZ(), result.apply(held)));
-                }
-                // restore previous held item
-                entity.setItemInHand(InteractionHand.MAIN_HAND, backupHack.copy());
-                backupHack = ItemStack.EMPTY;
-                cooldown = 600;
-            }
-        } else {
-            List<ItemEntity> items = entity.level().getEntitiesOfClass(ItemEntity.class, new AABB(entity.blockPosition().offset(-8, -8, -8).getBottomCenter(), entity.blockPosition().offset(8, 8, 8).getCenter()), (item) -> valid.test(item.getItem()));
-            if (items.isEmpty()) return;
-            ItemEntity nearest = items.stream().min(Comparator.comparingDouble(a -> a.distanceToSqr(entity))).orElse(null);
-            if (nearest.distanceToSqr(entity) < 2.25) {
-                // start barter: back up current held stack and take the item
-                progress = 100;
-                backupHack = entity.getMainHandItem().copy();
-                entity.setItemInHand(InteractionHand.MAIN_HAND, nearest.getItem().copy());
-                nearest.remove(RemovalReason.DISCARDED);
-                entity.level().playSound(null, entity.blockPosition(), SoundEvents.ITEM_PICKUP, SoundSource.HOSTILE, 0.2F, ((rand.nextFloat() - rand.nextFloat()) * 0.7F + 1.0F) * 2.0F);
-            } else {
-                entity.getNavigation().moveTo(nearest.getX(), nearest.getY(), nearest.getZ(), 1.0f);
-            }
-        }
-    }
-
-    @Override
     public boolean canUse() {
-        if (-- cooldown > 0) return false;
-        if (progress > 0 || entity.tickCount < lastTick + 20) return false;
-        lastTick = entity.tickCount;
-        List<ItemEntity> items = entity.level().getEntitiesOfClass(ItemEntity.class, new AABB(entity.blockPosition().offset(-8, -8, -8).getBottomCenter(), entity.blockPosition().offset(8, 8, 8).getCenter()), (item) -> valid.test(item.getItem()));
-        return !items.isEmpty();
+        if (entity.level().isClientSide) return false;
+
+        List<ItemEntity> items = entity.level().getEntitiesOfClass(
+            ItemEntity.class,
+            entity.getBoundingBox().inflate(8.0),
+            (item) -> valid.test(item.getItem())
+        );
+        if (items.isEmpty()) return false;
+        targetItem = items.get(0);
+        return targetItem != null && targetItem.isAlive();
     }
 
     @Override
     public boolean canContinueToUse() {
-        if (progress > 0) return true;
-        else { // walking towards item
-            List<ItemEntity> items = entity.level().getEntitiesOfClass(ItemEntity.class, new AABB(entity.blockPosition().offset(-8, -8, -8).getBottomCenter(), entity.blockPosition().offset(8, 8, 8).getCenter()), (item) -> valid.test(item.getItem()));
-            return !items.isEmpty();
+        if (entity.level().isClientSide) return false;
+        if (heldItem != null) return true;
+        if (targetItem == null || !targetItem.isAlive()) return false;
+        // Give up if item is too far away
+        return entity.distanceToSqr(targetItem) <= 256.0;
+    }
+
+    @Override
+    public void start() {
+        entity.getNavigation().stop();
+        pickupCooldown = 0;
+    }
+
+    @Override
+    public void stop() {
+        targetItem = null;
+        pickupCooldown = 0;
+        entity.getNavigation().stop();
+
+        if (heldItem != null) {
+            throwItem(heldItem.copy());
+            heldItem = null;
+        }
+        restorePreviousItem();
+    }
+
+    @Override
+    public void tick() {
+        if (entity.level().isClientSide) return;
+
+        if (heldItem != null) {
+            // TODO: this stops it from wandering, but doesn't stop it from trying
+            // Rely on the other goals to have it look at the player
+            entity.getNavigation().stop();
+            if (pickupCooldown > 0) {
+                pickupCooldown--;
+            } else {
+                throwItem(result.apply(heldItem));
+                heldItem = null;
+                restorePreviousItem();
+            }
+            return;
+        }
+
+        if (targetItem != null && targetItem.isAlive()) {
+            // Navigate to the target item
+            entity.getNavigation().moveTo(targetItem, speed);
+            entity.getLookControl().setLookAt(targetItem, 30.0f, 30.0f);
+
+            if (entity.distanceToSqr(targetItem) < 2.25) {
+                heldItem = targetItem.getItem().copy();
+                pickupCooldown = WAIT_TIME;
+
+                previousHeld = entity.getMainHandItem().copy();
+                entity.setItemInHand(InteractionHand.MAIN_HAND, heldItem.copy());
+
+                targetItem.remove(RemovalReason.DISCARDED);
+                targetItem = null;
+
+                entity.level().playSound(null, entity.blockPosition(), SoundEvents.ITEM_PICKUP, SoundSource.HOSTILE, 0.2F, ((rand.nextFloat() - rand.nextFloat()) * 0.7F + 1.0F) * 2.0F);
+            }
+        }
+    }
+
+    private void throwItem(ItemStack stack) {
+        Vec3 pos = entity.position().add(0, entity.getEyeHeight(), 0);
+        ItemEntity thrown = new ItemEntity(entity.level(), pos.x, pos.y, pos.z, stack);
+        Vec3 velocity = entity.getLookAngle().normalize().scale(0.2);
+        thrown.setDeltaMovement(velocity);
+        thrown.setPickUpDelay(20);
+        entity.level().addFreshEntity(thrown);
+    }
+
+    private void restorePreviousItem() {
+        if (previousHeld != null) {
+            entity.setItemInHand(InteractionHand.MAIN_HAND, previousHeld.isEmpty() ? ItemStack.EMPTY : previousHeld.copy());
+            previousHeld = null;
         }
     }
 }

--- a/src/main/java/alexthw/eidolon_repraised/common/entity/ai/PriestBarterGoal.java
+++ b/src/main/java/alexthw/eidolon_repraised/common/entity/ai/PriestBarterGoal.java
@@ -9,7 +9,7 @@ import java.util.function.Predicate;
 
 public class PriestBarterGoal extends GenericBarterGoal<Villager> {
     public PriestBarterGoal(Villager entity, Predicate<ItemStack> valid, Function<ItemStack, ItemStack> result) {
-        super(entity, valid, result);
+        super(entity, valid, result, 0.5f);
     }
 
     @Override

--- a/src/main/java/alexthw/eidolon_repraised/common/entity/ai/WitchBarterGoal.java
+++ b/src/main/java/alexthw/eidolon_repraised/common/entity/ai/WitchBarterGoal.java
@@ -8,7 +8,6 @@ import java.util.function.Predicate;
 
 public class WitchBarterGoal extends GenericBarterGoal<Witch> {
     public WitchBarterGoal(Witch entity, Predicate<ItemStack> valid, Function<ItemStack, ItemStack> result) {
-        super(entity, valid, result);
+        super(entity, valid, result, 1.0f);
     }
-
 }

--- a/src/main/java/alexthw/eidolon_repraised/event/Events.java
+++ b/src/main/java/alexthw/eidolon_repraised/event/Events.java
@@ -25,6 +25,7 @@ import alexthw.eidolon_repraised.network.SoulUpdatePacket;
 import alexthw.eidolon_repraised.network.WingsDataUpdatePacket;
 import alexthw.eidolon_repraised.registries.EidolonAttributes;
 import alexthw.eidolon_repraised.registries.EidolonCapabilities;
+import alexthw.eidolon_repraised.registries.EidolonDataComponents;
 import alexthw.eidolon_repraised.registries.EidolonPotions;
 import alexthw.eidolon_repraised.registries.Registry;
 import alexthw.eidolon_repraised.registries.Signs;
@@ -265,16 +266,16 @@ public class Events {
         if (event.getEntity() instanceof LivingEntity && !event.getLevel().isClientSide) {
             if (event.getEntity() instanceof Witch witch) {
                 witch.goalSelector.addGoal(1, new WitchBarterGoal(
-                        witch,
-                        stack -> stack.getItem() == Registry.CODEX.get(),
-                        stack -> CodexItem.withSign(stack, Signs.WICKED_SIGN)
+                    witch,
+                    stack -> stack.getItem() == Registry.CODEX.get() && !stack.has(EidolonDataComponents.SIGN),
+                    stack -> CodexItem.withSign(stack, Signs.WICKED_SIGN)
                 ));
             }
             if (event.getEntity() instanceof Villager villager) {
                 villager.goalSelector.addGoal(1, new PriestBarterGoal(
-                        villager,
-                        stack -> stack.getItem() == Registry.CODEX.get(),
-                        stack -> CodexItem.withSign(stack, Signs.SACRED_SIGN)
+                    villager,
+                    stack -> stack.getItem() == Registry.CODEX.get() && !stack.has(EidolonDataComponents.SIGN),
+                    stack -> CodexItem.withSign(stack, Signs.SACRED_SIGN)
                 ));
             }
             if (event.getEntity() instanceof PathfinderMob mob && (mob.getNavigation() instanceof GroundPathNavigation || mob.getNavigation() instanceof FlyingPathNavigation)) {


### PR DESCRIPTION
This is an attempt to fix the priest barter AI, which doesn't work for me on the released versions.  I don't know if this is a proper improvement, but it makes the sacred sign obtainable for me, so it's an improvement.  Feel free to take use any part of this, or just close it -- I'm just using it as a local patch.

The main improvements:
- Cache the targeted item rather than re-searching every tick
- Throw the item in the villager/witch's look direction, rather than dropping it straight down
- Filters searched items based on whether it has the sign component, so it doesn't try to pick up the same item again

Known issues:
- If unloaded while in progress, the book will be lost stuck in the witch/villager's hand
    - Future attempts will work, but the book is lost
- The books don't always show display properly on villagers
- The new book is thrown, but the throw direction doesn't always make sense